### PR TITLE
Fixed --always-make

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Options
     Show help
 --always-make 
     Always build fresh target even if dependency is up to date
+-B
+    Shortcut for --always-make
 -t GNUMAKEFILE
     Translates a GNU Makefile to a makeprog [incomplete]
 -f MAKEPROG

--- a/bin/plmake
+++ b/bin/plmake
@@ -13,8 +13,5 @@ if [ -z `which swipl` ]; then
     fi
 fi
 
-echo $SWIPL
-echo $PLMAKE_PATH
-
 $SWIPL -L0 -G0 -T0 -q -p library=$PLMAKE_PATH  -g main,halt -t halt -s $PLMAKE_PATH/plmake/plmake_cli -- "$@"
 ##swipl -g "use_module(library(plmake/plmake)),debug(build),consult_buildfile,build('$@')"

--- a/bin/plmake
+++ b/bin/plmake
@@ -1,14 +1,20 @@
 #!/bin/sh
 PATH_TO_ME=`dirname $0`;
 if [ -z "$PLMAKE_PATH" ]; then
-   PLMAKE_PATH=$PATH_TO_ME/../prolog;
+    PLMAKE_PATH=$PATH_TO_ME/../prolog;
 fi
 
 SWIPL=swipl
 if [ -z `which swipl` ]; then
-  # default location on OS X
-  SWIPL=/opt/local/bin/swipl;
+    # default locations on OS X
+    SWIPL=/Applications/SWI-Prolog.app/Contents/MacOS/swipl;
+    if [ -z $SWIPL ]; then
+	SWIPL=/opt/local/bin/swipl;
+    fi
 fi
+
+echo $SWIPL
+echo $PLMAKE_PATH
 
 $SWIPL -L0 -G0 -T0 -q -p library=$PLMAKE_PATH  -g main,halt -t halt -s $PLMAKE_PATH/plmake/plmake_cli -- "$@"
 ##swipl -g "use_module(library(plmake/plmake)),debug(build),consult_buildfile,build('$@')"

--- a/prolog/plmake/plmake.pl
+++ b/prolog/plmake/plmake.pl
@@ -96,11 +96,6 @@ debug_report(Topic,Fmt,Args,SL) :-
 % ----------------------------------------
 
 is_rebuild_required(T,_,SL,Opts) :-
-        member(always_make(true),Opts), % TODO
-        target_bindrule(T,_),
-        !,
-        report('Specified --always-make; building target ~w',[T],SL,Opts).
-is_rebuild_required(T,_,SL,Opts) :-
         \+ exists_target(T,Opts),
         !,
         report('Target ~w not materialized - will rebuild if required',[T],SL,Opts).
@@ -110,7 +105,11 @@ is_rebuild_required(T,DL,SL,Opts) :-
         is_built_after(D,T,Opts),
         !,
         report('Target ~w built before dependency ~w - rebuilding',[T,D],SL,Opts).
-
+is_rebuild_required(T,_,SL,Opts) :-
+        member(always_make(true),Opts),
+        target_bindrule(T,_),
+        !,
+        report('Specified --always-make; rebuilding target ~w',[T],SL,Opts).
 
 is_built_after(A,B,_Opts) :-
         time_file(A,TA),

--- a/prolog/plmake/plmake.pl
+++ b/prolog/plmake/plmake.pl
@@ -228,7 +228,7 @@ consult_makefile(F) :-
 
 consult_buildfile :- consult_buildfile('makespec.pro').
 consult_buildfile(F) :-
-        debug(build,'reading: ~w',[F]),
+        debug(buildfile,'reading: ~w',[F]),
         open(F,read,IO,[]),
         repeat,
         (   at_end_of_stream(IO)
@@ -302,7 +302,7 @@ normalize_patterns(X,X,_) :- var(X),!.
 normalize_patterns([],[],_) :- !.
 normalize_patterns([P|Ps],[N|Ns],V) :-
         !,
-        debug(buildfile,'*norm: ~w',[P]),
+        debug(pattern,'*norm: ~w',[P]),
         normalize_pattern(P,N,V),
         normalize_patterns(Ps,Ns,V).
 normalize_patterns(P,Ns,V) :-
@@ -318,10 +318,10 @@ normalize_pattern(t(X),t(X),_) :- !.
 normalize_pattern(Term,t(Args),_) :-
         Term =.. [t|Args],!.
 normalize_pattern(X,t(Toks),V) :-
-        debug(buildfile,'PARSING: ~w // ~w',[X,V]),
+        debug(pattern,'PARSING: ~w // ~w',[X,V]),
         atom_chars(X,Chars),
         phrase(toks(Toks,V),Chars),
-        debug(buildfile,'PARSED: ~w ==> ~w',[X,Toks]),
+        debug(pattern,'PARSED: ~w ==> ~w',[X,Toks]),
         !.
 
 toks([],_) --> [].
@@ -348,7 +348,7 @@ bindvar('*',v(X,_,_,_),X) :- !.
 bindvar('@',v(_,X,_,_),X) :- !.
 bindvar('<',v(_,_,X,_),X) :- !.
 bindvar(VL,v(_,_,_,_),X) :- global_binding(VL,X),!.
-bindvar(VL,v(_,_,_,BL),X) :- debug(buildfile,'binding ~w= ~w // ~w',[VL,X,BL]),member(VL=X,BL),debug(buildfile,'bound ~w= ~w',[VL,X]),!.
+bindvar(VL,v(_,_,_,BL),X) :- debug(pattern,'binding ~w= ~w // ~w',[VL,X,BL]),member(VL=X,BL),debug(pattern,'bound ~w= ~w',[VL,X]),!.
 
 
 

--- a/prolog/plmake/plmake.pl
+++ b/prolog/plmake/plmake.pl
@@ -37,8 +37,9 @@ build(T,Opts) :-
 
 build(T,SL,Opts) :-
         %report('Target: ~w',[T]),
+        debug_report(build,'  Target: ~w',[T],SL),
         target_bindrule(T,Rule),
-        debug(build3,'  Bindrule: ~w',[Rule]),
+        debug_report(build,'  Bindrule: ~w',[Rule],SL),
         rule_dependencies(Rule,DL,Opts),
         report('NT: ~w <-- ~w',[T,DL],SL,Opts),
         !,
@@ -49,7 +50,7 @@ build(T,SL,Opts) :-
         ;   true),
         report('NT: ~w is up to date',[T],SL,Opts).
 build(T,SL,Opts) :-
-        debug(build3,'  checking if rebuild required for ~w',[T]),
+        debug_report(build,'  checking if rebuild required for ~w',[T],SL),
         \+ is_rebuild_required(T,[],SL,Opts),
         !,
         report('T: ~w exists',[T],SL,Opts).
@@ -73,20 +74,32 @@ build_targets([T|TL],SL,Opts) :-
 report(Fmt,Args,Opts) :-
         report(Fmt,Args,[],Opts).
 
-report(Fmt,Args,SL,Opts) :-
-        maplist(write_tab(Opts),SL),
-        format(Fmt,Args),
+report(Fmt,Args,SL,_) :-
+        stack_indent(SL,Fmt,IndentedFmt),
+        format(IndentedFmt,Args),
         nl.
 
-write_tab(_,_) :- write('    ').
+stack_indent([],Text,Text).
+stack_indent([_|T],Text,Indented) :-
+        string_concat('    ',Text,Tab),
+	stack_indent(T,Tab,Indented).
+
+debug_report(Topic,Fmt,Args) :-
+        debug_report(Topic,Fmt,Args,[]).
+
+debug_report(Topic,Fmt,Args,SL) :-
+        stack_indent(SL,Fmt,IndentedFmt),
+	debug(Topic,IndentedFmt,Args).
 
 % ----------------------------------------
 % DEPENDENCY MANAGEMENT
 % ----------------------------------------
 
-is_rebuild_required(_,_,_,Opts) :-
+is_rebuild_required(T,_,SL,Opts) :-
         member(always_make(true),Opts), % TODO
-        !.
+        target_bindrule(T,_),
+        !,
+        report('Specified --always-make; building target ~w',[T],SL,Opts).
 is_rebuild_required(T,_,SL,Opts) :-
         \+ exists_target(T,Opts),
         !,
@@ -151,11 +164,11 @@ target_bindrule(T,rb(T,Ds,Execs)) :-
         % we allow multiple heads;
         % only one of the specified targets has to match
         member(TP,TPs),
-        debug(build3,'  pre TP/DPs: ~w / ~w ==> ~w',[TP,DPs,ExecPs]),
+        debug(bindrule,'  pre TP/DPs: ~w / ~w ==> ~w',[TP,DPs,ExecPs]),
         uniq_pattern_match(TP,T),
-        debug(build3,'  pst1 TP/DPs: ~w / ~w ==> ~w :: ~w',[TP,DPs,ExecPs,Goal]),
+        debug(bindrule,'  pst1 TP/DPs: ~w / ~w ==> ~w :: ~w',[TP,DPs,ExecPs,Goal]),
         Goal,
-        debug(build3,'  pst TP/DPs: ~w / ~w ==> ~w',[TP,DPs,ExecPs]),
+        debug(bindrule,'  pst TP/DPs: ~w / ~w ==> ~w',[TP,DPs,ExecPs]),
         maplist(pattern_target,DPs,Ds),
         maplist(toks_exec,ExecPs,Execs).
 
@@ -163,12 +176,12 @@ target_bindrule(T,rb(T,Ds,Execs)) :-
 
 % semidet
 uniq_pattern_match(TL,A) :-
-        debug(build3,'Matching: ~w to ~w',[TL,A]),
+        debug(bindrule,'Matching: ~w to ~w',[TL,A]),
         pattern_match(TL,A),
-        debug(build3,' Matched: ~w to ~w',[TL,A]),
+        debug(bindrule,' Matched: ~w to ~w',[TL,A]),
         !.
 uniq_pattern_match(TL,A) :-
-        debug(build3,' NO_MATCH: ~w to ~w',[TL,A]),
+        debug(bindrule,' NO_MATCH: ~w to ~w',[TL,A]),
         fail.
 
 
@@ -224,10 +237,10 @@ consult_buildfile(F) :-
         ;   read_term(IO,Term,[variable_names(VNs),
                                syntax_errors(error),
                                module(plmake)]),
-            debug(build3,'adding: ~w',[Term]),
+            debug(buildfile,'adding: ~w',[Term]),
             add_spec_clause(Term,VNs),
             fail),
-        debug(build3,'read: ~w',[F]),
+        debug(buildfile,'read: ~w',[F]),
         close(IO).
 
 add_spec_clause( (Var = X,{Goal}) ,VNs) :-
@@ -251,7 +264,7 @@ add_spec_clause( (Head <-- Deps) ,VNs) :-
 add_spec_clause(Rule,VNs) :-
         Rule =.. [mkrule|_],
         !,
-        debug(build3,'with: ~w ~w',[Rule,VNs]),
+        debug(buildfile,'with: ~w ~w',[Rule,VNs]),
         assert(with(Rule,VNs)).
 add_spec_clause(Term,_) :-
         assert(Term).
@@ -290,7 +303,7 @@ normalize_patterns(X,X,_) :- var(X),!.
 normalize_patterns([],[],_) :- !.
 normalize_patterns([P|Ps],[N|Ns],V) :-
         !,
-        debug(build3,'*norm: ~w',[P]),
+        debug(buildfile,'*norm: ~w',[P]),
         normalize_pattern(P,N,V),
         normalize_patterns(Ps,Ns,V).
 normalize_patterns(P,Ns,V) :-
@@ -306,10 +319,10 @@ normalize_pattern(t(X),t(X),_) :- !.
 normalize_pattern(Term,t(Args),_) :-
         Term =.. [t|Args],!.
 normalize_pattern(X,t(Toks),V) :-
-        debug(build3,'PARSING: ~w // ~w',[X,V]),
+        debug(buildfile,'PARSING: ~w // ~w',[X,V]),
         atom_chars(X,Chars),
         phrase(toks(Toks,V),Chars),
-        debug(build3,'PARSED: ~w ==> ~w',[X,Toks]),
+        debug(buildfile,'PARSED: ~w ==> ~w',[X,Toks]),
         !.
 
 toks([],_) --> [].
@@ -336,7 +349,7 @@ bindvar('*',v(X,_,_,_),X) :- !.
 bindvar('@',v(_,X,_,_),X) :- !.
 bindvar('<',v(_,_,X,_),X) :- !.
 bindvar(VL,v(_,_,_,_),X) :- global_binding(VL,X),!.
-bindvar(VL,v(_,_,_,BL),X) :- debug(build3,'binding ~w= ~w // ~w',[VL,X,BL]),member(VL=X,BL),debug(build3,'bound ~w= ~w',[VL,X]),!.
+bindvar(VL,v(_,_,_,BL),X) :- debug(buildfile,'binding ~w= ~w // ~w',[VL,X,BL]),member(VL=X,BL),debug(buildfile,'bound ~w= ~w',[VL,X]),!.
 
 
 

--- a/prolog/plmake/plmake_cli.pl
+++ b/prolog/plmake/plmake_cli.pl
@@ -58,7 +58,9 @@ arg_info('-h','','Show help').
 
 
 parse_arg(['--always-make'|L],L,always_make(true)).
+parse_arg(['-B'|L],L,always_make(true)).
 arg_info('--always-make','','Always build fresh target even if dependency is up to date').
+arg_info('-B','','Shortcut for --always-make').
 
 parse_arg(['-t',F|L],L,null) :-
         !,

--- a/prolog/plmake/plmake_cli.pl
+++ b/prolog/plmake/plmake_cli.pl
@@ -10,7 +10,7 @@ user:prolog_exception_hook(_,
 
 main :-
         current_prolog_flag(argv, Arguments),
-        append(_SytemArgs, [--|Args], Arguments),
+        (append(_SytemArgs, [--|Args], Arguments) ; =(Arguments,Args)),
         !,
         parse_args(Args,Opts_1),
         flatten(Opts_1,Opts),


### PR DESCRIPTION
This pull request fixes the --always-make option (previously it was attempting to rebuild dependencies for which there were no build rules), and adds the -B alias (c.f. GNU make).

Also added a line to the shell script wrapper to look for swipl in the default install path for version 7.2.3 of the SWI-Prolog application on OS X.

Some minor edits of debug logging code.