### PR TITLE
Fixed BSD-specific md5

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ This can also be installed via the SWI-Prolog pack system
 
 Just start SWI and type:
 
-    `?- pack_install('biomake').`
+    ?- pack_install('biomake').
 
 Command-line
 ------------
 
-    `biomake [-h] [-p MAKEPROG] [-f GNUMAKEFILE] [-l DIR] [-n|--dry-run] [-B|--always-make] [TARGETS...]`
+    biomake [-h] [-p MAKEPROG] [-f GNUMAKEFILE] [-l DIR] [-n|--dry-run] [-B|--always-make] [TARGETS...]
 
 Options
 -------

--- a/README.md
+++ b/README.md
@@ -228,11 +228,3 @@ Ideas for future development:
 * using other back ends and target sources (sqlite db, REST services)
 * cloud-based computing
 * running computes on clusters
-
-Examples
---------
-
-The makespec.pro in this project is used to make the pack release.
-
-See http://code.google.com/p/omeo/ - in particular,
-http://code.google.com/p/omeo/source/browse/trunk/build/makespec.pro

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ parentheses unless they are single letters.
 Unlike makefiles, biomake allows multiple variables in pattern
 matching. Let's say we have a program called `align` that compares two
 files producing some output (e.g. biological sequence alignment, or
-ontology alignment). Assume our file convention is to suffix `.fa` on
+ontology alignment). Assume our file convention is to suffix ".fa" on
 the inputs.  We can write a `Makespec.pro` with the following:
 
     'align-$X-$Y.tbl' <-- ['$X.fa', '$Y.fa'],

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ required. Add it to your path (changing the directory if necessary):
 
     biomake -h
 
-4. Create a 'makefile.pro' (see below)
+4. Create a 'Makespec.pro' or a 'Makefile' (see below)
 
 Alternate installation instructions
 -----------------------------------
@@ -72,24 +72,32 @@ Examples
 biomake looks for a Prolog file called `Makespec.pro` in your
 current directory. If it's not there, it will try looking for a
 `Makefile` in GNU Make format. The following examples describe the
-Prolog syntax; GNU Make syntax is described elsewhere, e.g. [here](https://www.gnu.org/software/make/manual/html_node/index.html).
+Prolog syntax; GNU Make syntax is described elsewhere,
+e.g. [here](https://www.gnu.org/software/make/manual/html_node/index.html).
 
-Assume you have two file formats, ".foo" and ".bar", and a foo2bar
+Assume you have two file formats, ".foo" and ".bar", and a `foo2bar`
 converter.
 
-Add the following rule to your Makespec.pro:
+Add the following rule to your `Makespec.pro`:
 
     '%.bar' <-- '%.foo',
         'foo2bar $< > $@'.
 
-Unlike makefiles, whitespace is irrelevant. Remember the closing ".",
+Unlike makefiles, whitespace is irrelevant. However, you
+do need the quotes, and remember the closing ".",
 as this is prolog syntax.
+
+If you prefer to stick with GNU Make syntax,
+the above `Makespec.pro` is equivalent to the following `Makefile`:
+
+    %.bar: %.foo
+    	   foo2bar $< > $@
 
 To convert a pre-existing file "x.foo" to "x.bar" type:
 
     biomake x.bar
 
-Let's say we can go from a .bar to a .baz using a bar2baz
+Let's say we can go from a .bar to a .baz using a `bar2baz`
 converter. We can add an additional rule:
 
     '%.baz' <-- '%.bar',
@@ -100,41 +108,50 @@ Now if we type:
     touch x.foo
     biomake x.baz
 
-The output will be something like:
+The output shows the tree structure of the dependencies:
 
-    NT: x.baz <-- [x.bar]
-      NT: x.bar <-- [x.foo]
-        T: x.foo
+    Checking dependencies: test.baz <-- [test.bar]
+        Checking dependencies: test.bar <-- [test.foo]
+            Nothing to be done for test.foo
+        Target test.bar not materialized - will rebuild if required
         foo2bar x.foo > x.bar
-      NT: x.bar is up to date
-      bar2baz x.bar > x.baz
-    NT: x.baz is up to date
-
-In the future the output format will be more configurable. The idea is
-to show the dependencies as a tree structure.
+        test.bar is up to date
+    Target test.baz not materialized - will rebuild if required
+    bar2baz x.bar > x.baz
+    test.baz is up to date
 
 The syntax in the makespec above is designed to be similar to what is
 already used in makefiles. You can bypass this and use prolog
 variables. The following form is functionally equivalent:
 
-    '$Base.bar' <-- '$Base.foo',
-        'foo2bar $Base.foo > $Base.bar'.
+    '$(Base).bar' <-- '$(Base).foo',
+        'foo2bar $(Base).foo > $(Base).bar'.
 
-Note that unlike Makefiles, the variables are not enclosed in
-parentheses. These are not Makefile variable, but are actually prolog
-variables (and must conform to prolog syntax - they must have a
-leading uppercase, and only alphanumeric characters plus underscore).
+The equivalent `Makefile` is
 
-You can mix and match if you like:
+    $(Base).foo:
+    	echo $(Base) >$@
 
-    '$Base.bar' <-- '$Base.foo',
+    $(Base).bar: $(Base).foo
+    	foo2bar $(Base).foo > $(Base).bar
+
+If you want the variables to work as Prolog variables as well
+as GNU Make variables, then they must conform to prolog syntax -
+they must have a leading uppercase, and only alphanumeric characters plus underscore.
+
+You can also use GNU Makefile constructs like automatic variables if you like:
+
+    '$(Base).bar' <-- '$(Base).foo',
         'foo2bar $< > $@'.
 
+Following the GNU Make convention, variable names must be enclosed in
+parentheses unless they are single letters.
+
 Unlike makefiles, biomake allows multiple variables in pattern
-matching. Let's say we have a program called "align" that compares two
+matching. Let's say we have a program called `align` that compares two
 files producing some output (e.g. biological sequence alignment, or
 ontology alignment). Assume our file convention is to suffix `.fa` on
-the inputs.  We can write a makespec with the following:
+the inputs.  We can write a `Makespec.pro` with the following:
 
     'align-$X-$Y.tbl' <-- ['$X.fa', '$Y.fa'],
         'align $X.fa $Y.fa > $@'.
@@ -194,34 +211,23 @@ We can create a top-level target that generates all solutions:
     'align-$X-$Y.tbl' <-- ['$X.obo', '$Y.obo'],
         'align $X.obo $Y.obo > $@'.
 
-It takes a little knowledge of prolog metalogical operators to
-construct the generator - in future there may be a convenient
-syntactic form that hides this.
-
 Now if we type:
 
     biomake all
 
 And all non-identical pairs are compared (in one direction only - the
-assumption is that "align" is symmetric).
+assumption is that the `align` program is symmetric).
 
 More
 ----
 
-There are a few more features that will be documented in the
-future. The core will likely stay minimal. The core system is
-extensive and powerful so you should be able to do lots by
-using/abusing either prolog or shell wrappers.
-
-In the future there may be extensions for:
+Ideas for future development:
 
 * a web-based build environment (a la Galaxy)
 * semantic web enhancement (using NEPOMUK file ontology)
 * using other back ends and target sources (sqlite db, REST services)
 * cloud-based computing
 * running computes on clusters
-* make2biomake partial translator
-* alternate syntaxes
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Note that here the rule consists of 4 parts:
 In this case, the prolog goal succeeds with 9 solutions, with 3
 different values for X and Y. If we type:
 
-  biomake align-platypus-coelocanth.tbl
+    biomake align-platypus-coelocanth.tbl
 
 It will not succeed, even if the .fa files are on the filesystem. This
 is because the goal cannot be satisfied for these two values.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Getting Started
 2. Get the latest biomake source from github. No installation steps are
 required. Add it to your path (changing the directory if necessary):
 
-    export PATH=$PATH:$HOME/biomake/bin
+    `export PATH=$PATH:$HOME/biomake/bin`
 
 3. Get (minimal) help from the command line:
 
-    biomake -h
+    `biomake -h`
 
 4. Create a 'Makespec.pro' or a 'Makefile' (see below)
 
@@ -31,12 +31,12 @@ This can also be installed via the SWI-Prolog pack system
 
 Just start SWI and type:
 
-   ?- pack_install('biomake').
+    `?- pack_install('biomake').`
 
 Command-line
 ------------
 
-  biomake [-h] [-p MAKEPROG] [-f GNUMAKEFILE] [-l DIR] [-n|--dry-run] [-B|--always-make] [TARGETS...]
+    `biomake [-h] [-p MAKEPROG] [-f GNUMAKEFILE] [-l DIR] [-n|--dry-run] [-B|--always-make] [TARGETS...]`
 
 Options
 -------

--- a/examples/ontology_alignment.pro
+++ b/examples/ontology_alignment.pro
@@ -32,24 +32,24 @@ all <-- Deps,
 'all-%' <-- ['%.owl', '%.owx'].
 
 % obo2owl WITH dangling
-'$Base.$Fmt' <-- ['$Base.obo'],
+'$(Base).$(Fmt)' <-- ['$(Base).obo'],
        {allow_dangling(Base),suffix_fmt(Fmt,FmtName)},
-       'obolib-obo2owl --to $FmtName --allow-dangling $< -o $@ >& $@.err'.
+       'obolib-obo2owl --to $(FmtName) --allow-dangling $< -o $@ >& $@.err'.
 
 % obo2owl NO dangling
-'$Base.$Fmt' <-- ['$Base.obo'],
+'$(Base).$(Fmt)' <-- ['$(Base).obo'],
        {\+ allow_dangling(Base),suffix_fmt(Fmt,FmtName)},
-       'obolib-obo2owl --to $FmtName $< -o $@ >& $@.err'.
+       'obolib-obo2owl --to $(FmtName) $< -o $@ >& $@.err'.
 
 
 suffix_fmt(mos,manchester).
 suffix_fmt(owx,owlxml).
 suffix_fmt(owl,'RDFXML').
 
-'$Base.metadata' <-- ['$Base.owl'],
+'$(Base).metadata' <-- ['$(Base).owl'],
        'owltools file://`pwd`/$<  --show-metadata > $@'.
 
-'$Base.closure' <-- ['$Base.owl'],
+'$(Base).closure' <-- ['$(Base).owl'],
        'owltools file://`pwd`/$<  --save-closure -c $@'.
 
 % ----------------------------------------
@@ -79,8 +79,8 @@ align_all <-- Deps,
 
 % GENERIC
 
-'$Dir/' <-- [],
-  'mkdir -p $Dir'.
+'$(Dir)/' <-- [],
+  'mkdir -p $(Dir)'.
 
 
 

--- a/prolog/biomake/biomake_cli.pl
+++ b/prolog/biomake/biomake_cli.pl
@@ -118,8 +118,8 @@ parse_arg(['-l',F|L],L,
         !.
 arg_info('-l','DIRECTORY','Iterates through directory writing metadata on each file found').
 
-parse_arg(['-H'|L],L,md5(true)) :- ensure_loaded(library(biomake/md5)), !.
-parse_arg(['--md5-hash'|L],L,md5(true)) :- ensure_loaded(library(biomake/md5)), !.
+parse_arg(['-H'|L],L,md5(true)) :- ensure_loaded(library(biomake/md5hash)), !.
+parse_arg(['--md5-hash'|L],L,md5(true)) :- ensure_loaded(library(biomake/md5hash)), !.
 arg_info('-H,--md5-hash','','Use MD5 hashes instead of timestamps').
 
 parse_arg(['--no-backtrace'|L],L,quiet(true)) :- assert(no_backtrace), !.

--- a/prolog/biomake/biomake_cli.pl
+++ b/prolog/biomake/biomake_cli.pl
@@ -21,8 +21,9 @@ main :-
 	consult_makefile(Opts),
         forall(member(goal(G),Opts),
                G),
-	build_toplevel(Opts),
-        halt.
+	(build_toplevel(Opts)
+	 -> halt(0)
+	 ;  halt(1)).
 
 build_toplevel(Opts) :-
 	member(toplevel(_),Opts),

--- a/prolog/biomake/biomake_db.pl
+++ b/prolog/biomake/biomake_db.pl
@@ -76,8 +76,5 @@ time_file_wrap(_,-).
 
 show_stored_targets :-
         forall(stored_target(T,DL,S,T1,T2),
-               print_message(informational,stored_target(T,DL,S,T1,T2))).
-
-prolog:message(stored_target(T,DL,S,T1,T2)) -->
-        {atomic_list_concat(DL,' ',DLA)},
-        [T,' [',DLA,'] ',S,' ',T1,' ',T2].
+	       (atomic_list_concat(DL,' ',DLA),
+	        format("~w [~w] ~w ~w ~w~n",[T,DLA,S,T1,T2]))).

--- a/prolog/biomake/md5hash.pl
+++ b/prolog/biomake/md5hash.pl
@@ -1,12 +1,13 @@
 % * -*- Mode: Prolog -*- */
 
-:- module(md5,
+:- module(md5hash,
           [
 	      md5_hash_up_to_date/3,
 	      update_md5_file/2
           ]).
 
-:- use_module(library(md5), [ md5/2 as library_md5 ]).
+:- use_module(library(md5), [ md5_hash/3 as library_md5_hash ]).
+:- use_module(library(readutil)).
 
 % ----------------------------------------
 % MD5 HASHES
@@ -70,6 +71,7 @@ compute_md5(T,Size,Hash) :-
     retract_md5_hash(T),
     assert(md5_hash(T,Size,Hash)).
 
+% try all the md5 executables specified with md5_prog
 try_md5_prog(Filename,Hash) :-
     md5_prog(Md5Prog),
     format(string(Exec),"~w ~w",[Md5Prog,Filename]),
@@ -78,6 +80,11 @@ try_md5_prog(Filename,Hash) :-
     phrase(first_n(32,HashCodes),ExecOut),
     string_codes(HashStr,HashCodes),
     string_lower(HashStr,Hash).
+
+% fall back to using Prolog's in-memory MD5 implementation
+try_md5_prog(Filename,Hash) :-
+    read_file_to_string(Filename,Str,[]),
+    library_md5_hash(Str,Hash,[]).
 
 first_n(0,[]) --> [].
 first_n(0,[]) --> [_], first_n(0,[]).

--- a/prolog/biomake/md5hash.pl
+++ b/prolog/biomake/md5hash.pl
@@ -83,6 +83,7 @@ try_md5_prog(Filename,Hash) :-
 
 % fall back to using Prolog's in-memory MD5 implementation
 try_md5_prog(Filename,Hash) :-
+    debug(md5,'reading ~w into memory for native SWI-Prolog MD5 implementation',[Filename]),
     read_file_to_string(Filename,Str,[]),
     library_md5_hash(Str,Hash,[]).
 

--- a/prolog/biomake/utils.pl
+++ b/prolog/biomake/utils.pl
@@ -31,7 +31,7 @@
 	   file_directory_slash/2,
 	   quote_string/2,
 	   newlines_to_spaces/2,
-	   to_strings/2,
+	   to_string/2,
 	   equal_as_strings/2
 	  ]).
 

--- a/prolog/biomake/utils.pl
+++ b/prolog/biomake/utils.pl
@@ -1,6 +1,6 @@
 % * -*- Mode: Prolog -*- */
 
-:- module(parser_utils,
+:- module(utils,
           [
            show_type/1,
            type_of/2,
@@ -110,8 +110,11 @@ type_of(X,"atom") :- atom(X), !.
 type_of(_,"unknown").
 
 shell_eval(Exec,CodeList) :-
-	process_create(path(sh),['-c',Exec],[stdout(pipe(Stream))]),
+        process_create(path(sh),['-c',Exec],[stdout(pipe(Stream)),
+					     stderr(null),
+					     process(Pid)]),
         read_stream_to_codes(Stream,CodeList),
+	process_wait(Pid,_Status),
         close(Stream).
 
 shell_eval_str(Exec,Result) :-


### PR DESCRIPTION
- fixes #10 by trying md5sum, then md5, then falling back to SWI-Prolog's in-memory MD5 implementation
- fixes the `-l` option (scan directory outputting metadata) which I don't quite understand the use case for but fixed anyway since I think I broke it at some point ;)
- updated the examples directory and the README to reflect some relatively minor (IMO) changes I had to make to bring syntax in line with GNU make
